### PR TITLE
cleanly print vulnerability's path

### DIFF
--- a/src/main/java/io/jenkins/plugins/grypescanner/GrypeScannerStep.java
+++ b/src/main/java/io/jenkins/plugins/grypescanner/GrypeScannerStep.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.grypescanner;
 import java.io.IOException;
 import java.net.URL;
 
-import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -25,7 +24,7 @@ import net.sf.json.JSONObject;
 
 public class GrypeScannerStep extends Builder implements SimpleBuildStep
 {
-  private static final String SCAN_TARGET_DEFAULT = "dir:/";
+  private static final String SCAN_TARGET_DEFAULT = "dir:./";
   private static final String REP_NAME_DEFAULT = "grypeReport_${JOB_NAME}_${BUILD_NUMBER}.txt";
 
   private String scanDest;
@@ -69,9 +68,11 @@ public class GrypeScannerStep extends Builder implements SimpleBuildStep
     String repNameResolved = Util.replaceMacro(repName, run.getEnvironment(listener));
 
     FilePath grypeTmpDir = workspace.child("grypeTmpDir");
-    FilePath templateFile = grypeTmpDir.child("default.tmpl");
     grypeTmpDir.mkdirs();
-    templateFile.copyFrom(GrypeScannerStep.class.getResource("/default.tmpl"));
+
+    FilePath templateFile = grypeTmpDir.child("default.tmpl");
+    templateFile.copyFrom(getClass().getResource("default.tmpl"));
+
     listener.getLogger().println("Running grype scan: ");
     FilePath resultReport = workspace.child(repNameResolved);
     final String grypeCmd;

--- a/src/main/resources/default.tmpl
+++ b/src/main/resources/default.tmpl
@@ -1,4 +1,0 @@
-"Package","Version Installed","Vulnerability ID","Severity","Locations"
-{{- range .Matches}}
-"{{.Artifact.Name}}","{{.Artifact.Version}}","{{.Vulnerability.ID}}","{{.Vulnerability.Severity}}","{{.Artifact.Locations}}"
-{{- end}}

--- a/src/main/resources/io/jenkins/plugins/grypescanner/GrypeScannerStep/help.html
+++ b/src/main/resources/io/jenkins/plugins/grypescanner/GrypeScannerStep/help.html
@@ -1,14 +1,3 @@
 <div>
-	A <a href="https://github.com/anchore/grype">vulnerability scanner</a>
-	for container images and filesystems.
-
-	<p>
-		<strong>Usage in a pipeline:</strong><br> pipeline <br>{<br>
-		&nbsp;agent
-		any<br> &nbsp;options {<br> &nbsp;skipStagesAfterUnstable()<br> }<br>
-		stages <br> {<br>&nbsp;stage('Build')<br>&nbsp;{<br>&nbsp;&nbsp;steps<br>&nbsp;&nbsp;{<br>
-		&nbsp;&nbsp;step([$class: 'GrypeScannerStep', scanDest: 'dir:/tmp', repName:
-		'myScanResult.txt'])<br>&nbsp;&nbsp;}<br>&nbsp;}<br> }<br> }<br>
-	</p>
-
+	Allow usage of <a href="https://github.com/anchore/grype">grype</a>, a vulnerability scanner for container images and filesystems.
 </div>

--- a/src/main/resources/io/jenkins/plugins/grypescanner/default.tmpl
+++ b/src/main/resources/io/jenkins/plugins/grypescanner/default.tmpl
@@ -1,0 +1,4 @@
+"Package","Version Installed","Vulnerability ID","Severity","Locations"
+{{- range .Matches}}
+"{{.Artifact.Name}}","{{.Artifact.Version}}","{{.Vulnerability.ID}}","{{.Vulnerability.Severity}}","{{range $index, $location := .Artifact.Locations}}{{if $index}} {{end}}{{$location.RealPath}}{{end}}"
+{{- end}}


### PR DESCRIPTION
cleanly print vulnerability's path instead of relying on Go template list serialization.

This means that generated locations will now looks like
```
xmlbeans-2.6.0.jar
```
and not like this anymore:
```
[Location<RealPath="xmlbeans-2.6.0.jar">]
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
